### PR TITLE
Updating mix cloud elements and servers

### DIFF
--- a/index.php
+++ b/index.php
@@ -50,9 +50,11 @@ $output = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 
 		";
 
-while($page <= $nb_pages) {
+$nextURL = null;
+do {
 	/* First get the info page for this playlist */
-	$my_podcast_page = curlGet('http://www.mixcloud.com/'.$my_podcast.'/?page='.$page);
+	$url = $nextURL ? $nextURL : $my_podcast;
+	$my_podcast_page = file_get_contents('http://www.mixcloud.com/'.$url);
 
 	$my_podcast_page = mb_convert_encoding($my_podcast_page, 'HTML-ENTITIES', "UTF-8");
 
@@ -60,9 +62,13 @@ while($page <= $nb_pages) {
 	/* hide warnings - html docs likely won't parse correctly */ 
 	libxml_use_internal_errors(true);
 	$doc->loadHTML($my_podcast_page); 
-
 	
 	$xpath = new DOMXpath($doc);
+
+	if ($xpath->query('//div[@class="infinitescroll-end"]')->length == 0) {
+		break;
+	}
+	$nextURL = $xpath->query('//div[@class="infinitescroll-end"]')->item(0)->getAttribute("m-next-page-url");
 	
 	$episodes = $xpath->query('//div[@class="card-elements-container cf"]'); 
 	//echo '<p>episodes has '. $episodes->length .'</p>';
@@ -72,17 +78,22 @@ while($page <= $nb_pages) {
 			$episode_image = $xpath->query('.//div[@class="card-cloudcast-image"]/a/img',$container);
 			$large_photo = 'http:' . $episode_image->item(0)->getAttribute("src");
 			$episode_info = $xpath->query('.//div[@class="card-cloudcast-image"]/span',$container);
+			if ($episode_info->length == 0) { //episodes that are disabled have no title
+				continue;
+			}
 			$e_title = $episode_info->item(0)->getAttribute("m-title");
 			$e_url = 'http://www.mixcloud.com'. $episode_info->item(0)->getAttribute("m-url");
 			$e_description = json_decode(curlGet('http://api.mixcloud.com'.$episode_info->item(0)->getAttribute("m-url")))->description;
-			$e_preview = $episode_info->item(0)->getAttribute("m-preview"); 
-			$e_server = substr($e_preview,0,29); 
+			$e_preview = $episode_info->item(0)->getAttribute("m-preview");
+			$length = strpos($e_preview, "preview");
+			$e_server = substr($e_preview,0,$length - 1);
+			$e_server = str_replace("audiocdn", "stream", $e_server);
 			// todo - should not just be 39 magic number, but where 'preview/' is in url
-			$e_identifier = substr($e_preview,39); 
+			$e_identifier = substr($e_preview,$length + 9);
 			$e_identifier = rtrim($e_identifier,".mp3"); 
 			$e_download =  $e_server . '/c/m4a/64/'. $e_identifier .'.m4a'; 
 			$e_original = $e_server . '/c/originals/' . $e_identifier . '.mp3';
-			$item_size = get_Size($e_original);
+			$item_size = get_Size($e_download);
 			/* if $item_size is 168 this means not found */ 
 			if($item_size > 200) {
 				$episode_update = $xpath->query('.//div[@class="card-stats cf"]/span[@class="card-date"]/time',$container); 
@@ -97,15 +108,14 @@ while($page <= $nb_pages) {
 				<link>$e_url</link>
 				<description><![CDATA[$e_description]]></description>
 				<itunes:image href=\"$large_photo\" />
-				<enclosure url=\"$e_original\" length=\"$item_size\" type=\"audio/mp4\" />
+				<enclosure url=\"$e_download\" length=\"$item_size\" type=\"audio/mp4\" />
 				<guid isPermaLink=\"true\">$e_url</guid>
 			</item>
 				";
 			}
 		}
 	}
-	++$page;
-}
+} while ($nextURL);
 
 /* seems like we're getting the closing footer too early */
 sleep(2); 

--- a/index.php
+++ b/index.php
@@ -22,10 +22,7 @@ $itunes_image = $user_info->pictures->large;
 $my_description = stripslashes($user_info->biog);
 $updated = date(DATE_RSS,strtotime($user_info->updated_time));
 $my_title = $user_info->name;
-$my_link = $user_info->url; 
-$nb_podcasts = $user_info->cloudcast_count; 
-$nb_pages = ceil($nb_podcasts/24); // 24 cloudcasts per page
-$page = 1; 
+$my_link = $user_info->url;
  
 /* write out the outer shell, channel, globals */ 
 $updated= date("D, d M Y H:i:s T",strtotime("now"));

--- a/index.php
+++ b/index.php
@@ -95,7 +95,7 @@ do {
 			if($item_size > 200) {
 				$episode_update = $xpath->query('.//div[@class="card-stats cf"]/span[@class="card-date"]/time',$container); 
 				if($episode_update) {
-					$pubDate = strtotime($episode_update->item(0)->getAttribute("datetime"));
+					$pubDate = strtotime($episode_update->item(0)->nodeValue);
 				} else {
 					$pubDate = "false";
 				} 


### PR DESCRIPTION
Looks like originals server was not found.
Updated paging mechanism that follows paging html entities.
Updated check of preview string length to properly retrieve server address and full path
Also skipping episodes that have been disabled due to licensing.
